### PR TITLE
fix(dnsScan): report empty DNS results instead of silent break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v5.4.4
+
+### Fixes
+
+- **No-DNS domains**: A domain with no DNS records (e.g. NXDOMAIN / typo) now prints "No DNS records found - the domain may not resolve." instead of a bare, empty "DNS records:" header that read as a silent failure
+
+### Improvements
+
+- **Results header**: Dropped the redundant target from the `# webscan results for <target>` header - the scanned target is already shown by the caller
+- **Dead code**: Removed six unused `Engine` result fields (and their imports) orphaned by the v5.4.3 scan-orchestration refactor
+
 ## v5.4.3
 
 ### Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# webscan
+
+CLI + web scanner. `cmd/webscan` (CLI), `cmd/webscan-web` (server). Scan engine: `pkg/webscan/`, per-scan packages `pkg/*Scan/`.
+
+## Hosted deployment (hydra)
+
+Runs on the hydra cluster. Connect: see the `kubernetes-kind` skill (`KUBECONFIG=~/code/thetillhoff/infra/pulumi/kubeconfig`, `--context=admin@hydra`).
+
+- Namespace: `webscan`. Manifests: `~/code/thetillhoff/infra/kubernetes/apps/hydra/webscan/` (Flux/GitOps, image bumped by image-automation).
+- Web mode queues scan jobs; each job's status/result/output lives in **redis** (`deploy/redis`), keyed `webscan:job:<id>`.
+
+Check a stuck/silent scan:
+
+```bash
+kubectl logs deploy/webscan -n webscan --context=admin@hydra --tail=100
+kubectl exec deploy/redis -n webscan --context=admin@hydra -- redis-cli KEYS 'webscan:job:*'
+kubectl exec deploy/redis -n webscan --context=admin@hydra -- redis-cli HGETALL webscan:job:<id>
+```
+
+On timeout the worker writes `status=timeout` to redis but logs nothing — an apparent "silent break" in the logs. Check the job's redis fields (`status`, `error`, `duration`) before assuming a crash.
+
+## Version
+
+Released tags can run **ahead** of local `main` (deployed prod may be a newer `vX.Y.Z` than `git describe`). Before editing to fix prod behavior, `git fetch --tags` and check out the deployed tag — the fix may already exist.

--- a/pkg/dnsScan/PrintResult.go
+++ b/pkg/dnsScan/PrintResult.go
@@ -44,10 +44,16 @@ func PrintResult(result Result, out io.Writer) {
 		slog.Debug("dnsScan: No blacklist entries found")
 	}
 
-	if _, err := fmt.Fprintf(out, "DNS records:\n"); err != nil {
-		slog.Debug("dnsScan: Error writing to output", "error", err)
+	if result.hasPrintableRecords() {
+		if _, err := fmt.Fprintf(out, "DNS records:\n"); err != nil {
+			slog.Debug("dnsScan: Error writing to output", "error", err)
+		}
+		result.PrintAllDnsRecords(out)
+	} else {
+		if _, err := fmt.Fprintf(out, "No DNS records found - the domain may not resolve.\n"); err != nil {
+			slog.Debug("dnsScan: Error writing to output", "error", err)
+		}
 	}
-	result.PrintAllDnsRecords(out)
 
 	// Domain Accessibility
 	if len(result.OpinionatedHints) > 0 {

--- a/pkg/dnsScan/PrintResult_test.go
+++ b/pkg/dnsScan/PrintResult_test.go
@@ -1,0 +1,35 @@
+package dnsScan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrintResultEmpty(t *testing.T) {
+	var out strings.Builder
+	PrintResult(Result{}, &out)
+
+	got := out.String()
+	if !strings.Contains(got, "No DNS records found") {
+		t.Errorf("empty result should report no records, got:\n%s", got)
+	}
+	if strings.Contains(got, "DNS records:") {
+		t.Errorf("empty result should not print the records header, got:\n%s", got)
+	}
+}
+
+func TestPrintResultWithRecords(t *testing.T) {
+	var out strings.Builder
+	PrintResult(Result{ARecords: []string{"192.0.2.1"}}, &out)
+
+	got := out.String()
+	if !strings.Contains(got, "DNS records:") {
+		t.Errorf("result with records should print the header, got:\n%s", got)
+	}
+	if strings.Contains(got, "No DNS records found") {
+		t.Errorf("result with records should not report empty, got:\n%s", got)
+	}
+	if !strings.Contains(got, "192.0.2.1") {
+		t.Errorf("A record should be printed, got:\n%s", got)
+	}
+}

--- a/pkg/dnsScan/Result.go
+++ b/pkg/dnsScan/Result.go
@@ -18,3 +18,13 @@ type Result struct {
 	IpVersionCompatibility   string
 	DomainAccessibilityHints []string
 }
+
+// hasPrintableRecords reports whether PrintAllDnsRecords would emit any record.
+func (result Result) hasPrintableRecords() bool {
+	return len(result.NSRecords) > 0 ||
+		len(result.ARecords) > 0 ||
+		len(result.AAAARecords) > 0 ||
+		result.CNAMERecord != "" ||
+		len(result.MXRecords) > 0 ||
+		len(result.TXTRecords) > 0
+}

--- a/pkg/webscan/Engine.go
+++ b/pkg/webscan/Engine.go
@@ -10,11 +10,8 @@ import (
 
 	"github.com/thetillhoff/webscan/v5/pkg/cachedHttpGetClient"
 	"github.com/thetillhoff/webscan/v5/pkg/dnsScan"
-	"github.com/thetillhoff/webscan/v5/pkg/htmlContentScan"
-	"github.com/thetillhoff/webscan/v5/pkg/httpHeaderScan"
 	"github.com/thetillhoff/webscan/v5/pkg/httpProtocolScan"
 	"github.com/thetillhoff/webscan/v5/pkg/ipScan"
-	"github.com/thetillhoff/webscan/v5/pkg/knownFilesScan"
 	"github.com/thetillhoff/webscan/v5/pkg/portScan"
 	"github.com/thetillhoff/webscan/v5/pkg/status"
 	"github.com/thetillhoff/webscan/v5/pkg/subDomainScan"
@@ -54,18 +51,12 @@ type Engine struct {
 	subDomainScan    bool
 
 	// Results
-	dnsScanResult              dnsScan.Result
-	ipScanResult               ipScan.Result
-	portScanResult             portScan.Result
-	tlsScanResult              tlsScan.Result
-	httpProtocolScanResult     httpProtocolScan.Result
-	httpHeaderScanResult       httpHeaderScan.Result
-	httpsHeaderScanResult      httpHeaderScan.Result
-	httpHtmlContentScanResult  htmlContentScan.Result
-	httpsHtmlContentScanResult htmlContentScan.Result
-	httpKnownFilesScanResult   knownFilesScan.Result
-	httpsKnownFilesScanResult  knownFilesScan.Result
-	subDomainScanResult        subDomainScan.Result
+	dnsScanResult          dnsScan.Result
+	ipScanResult           ipScan.Result
+	portScanResult         portScan.Result
+	tlsScanResult          tlsScan.Result
+	httpProtocolScanResult httpProtocolScan.Result
+	subDomainScanResult    subDomainScan.Result
 	// mailConfigScanResults []string // TODO find better type
 }
 

--- a/pkg/webscan/Scan.go
+++ b/pkg/webscan/Scan.go
@@ -138,7 +138,7 @@ func (engine *Engine) Scan(ctx context.Context, input string) error {
 		return err
 	}
 
-	if _, err := fmt.Fprintf(engine.stdout, "# webscan results for %s\n\n", engine.target.RawTarget()); err != nil {
+	if _, err := fmt.Fprintf(engine.stdout, "# webscan results\n\n"); err != nil {
 		slog.Debug("webscan: Error writing to output", "error", err)
 	}
 


### PR DESCRIPTION
## What

A domain with no DNS records (NXDOMAIN / typo, e.g. `blaskapelle-badwiesse.de`) printed a bare `DNS records:` header with nothing under it - which read as a silent break in both CLI and hosted web output.

## Changes

- **No-DNS feedback**: print `No DNS records found - the domain may not resolve.` when the DNS result is empty.
- **Header**: drop the redundant `for <target>` from `# webscan results for X` (the caller already shows the target).
- **Dead code**: remove six unused `Engine` result fields + imports orphaned by the v5.4.3 orchestration refactor (they were failing golangci-lint).
- CHANGELOG entry for v5.4.4; new `CLAUDE.md` documenting the hydra deployment + redis job inspection.

## Test

Added `pkg/dnsScan/PrintResult_test.go`; verified end-to-end against an NXDOMAIN domain and a resolving one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)