### PR TITLE
docs: note main protection and release flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ kubectl exec deploy/redis -n webscan --context=admin@hydra -- redis-cli HGETALL 
 
 On timeout the worker writes `status=timeout` to redis but logs nothing — an apparent "silent break" in the logs. Check the job's redis fields (`status`, `error`, `duration`) before assuming a crash.
 
-## Version
+## Version & releasing
 
 Released tags can run **ahead** of local `main` (deployed prod may be a newer `vX.Y.Z` than `git describe`). Before editing to fix prod behavior, `git fetch --tags` and check out the deployed tag — the fix may already exist.
+
+`main` is a **protected branch**: direct `git push origin main` is rejected (`protected branch hook declined`; `enforce_admins` on, required check `verify-version`). All changes land via PR — `gh pr merge <n> --merge --delete-branch`. There is no local-merge-and-push path.
+
+Release = push a `vX.Y.Z` tag (only after the change is merged to `main`). The `release-on-tag` workflow builds the executables + pushes the ghcr image (`ghcr.io/thetillhoff/webscan:X.Y.Z`, no `v`); Flux image-automation on hydra then scans, bumps the deployment, and rolls it out — usually within minutes, no manual step. Force it early with the `ci-build-then-flux-reconcile` skill. Renovate dep PRs auto-tag a patch bump via `tag-on-main`; human releases are tagged manually.


### PR DESCRIPTION
## Summary

- Document that `main` is a protected branch (direct push rejected; changes land via PR).
- Document the release flow: tag `vX.Y.Z` after merge → `release-on-tag` builds + pushes the ghcr image → Flux auto-deploys on hydra.

Captures what was rediscovered during the v5.4.4 release so the next one doesn't repeat it.